### PR TITLE
Implementing an API worker to obtain course information

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ repositories {
 dependencies {
 	implementation 'junit:junit:4.13.1'
 	testImplementation('org.junit.jupiter:junit-jupiter:5.6.0')
+	implementation 'com.google.code.gson:gson:2.8.8'
 }
 
 spotless {

--- a/src/main/java/APIWorker.java
+++ b/src/main/java/APIWorker.java
@@ -1,0 +1,45 @@
+import com.google.gson.*;
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.util.HashMap;
+
+public class APIWorker {
+    private final String api_template =
+            "https://timetable.iit.artsci.utoronto.ca/api/20219/courses?org=&code=COURSENAME&section=&studyyear=&daytime=&weekday=&prof=&breadth=&deliverymode=&online=&waitlist=&available=&fyfcourse=&title=";
+    String course_JSON;
+
+    public APIWorker(String new_id) {
+        this.course_JSON = api_template.replace("COURSENAME", new_id);
+    }
+
+    private static String readUrl(String urlString) throws Exception {
+        BufferedReader reader = null;
+        try {
+            URL url = new URL(urlString);
+            reader = new BufferedReader(new InputStreamReader(url.openStream()));
+            StringBuffer buffer = new StringBuffer();
+            int read;
+            char[] chars = new char[1024];
+            while ((read = reader.read(chars)) != -1) buffer.append(chars, 0, read);
+
+            return buffer.toString();
+        } finally {
+            if (reader != null) reader.close();
+        }
+    }
+
+    public void main(String[] args) throws Exception {
+        String json = readUrl(this.course_JSON);
+        Gson payload = new Gson();
+        HashMap<String, Object> map = new HashMap<>();
+        map = (HashMap<String, Object>) payload.fromJson(json, map.getClass());
+
+        System.out.println(map);
+    }
+
+    @Override
+    public String toString() {
+        return String.format(this.course_JSON);
+    }
+}

--- a/src/main/java/Scheduler.java
+++ b/src/main/java/Scheduler.java
@@ -1,9 +1,7 @@
 import java.util.ArrayList;
 
 public class Scheduler {
-    private final ArrayList schedules;
-
     public Scheduler() {
-        this.schedules = new ArrayList<>();
+        ArrayList schedules = new ArrayList<>();
     }
 }


### PR DESCRIPTION
Currently, I have not tested whether the ```gson``` implementation works or not. The idea is to turn the JSON at the URL into a ```Hashmap<String, Object>``` to use later. [Here](https://timetable.iit.artsci.utoronto.ca/api/20219/courses?org=&code=MAT237&section=&studyyear=&daytime=&weekday=&prof=&breadth=&deliverymode=&online=&waitlist=&available=&fyfcourse=&title=) is a sample API endpoint for MAT237.

We can also change the name to something more accurate if you can come up with one.

