### PR TITLE
implemented one-by-one generation

### DIFF
--- a/src/main/java/controllers/CommandLineInterface.java
+++ b/src/main/java/controllers/CommandLineInterface.java
@@ -23,8 +23,6 @@ public class CommandLineInterface {
     /** Constructor.
      *
      * @param mode represents one by one generation for the Controller
-     * 0 -> creates all permutations
-     * 1 -> one by one generation
      *
      * if one by one generation is used in controller, displayUserSchedule will take input to return a schedule
      */

--- a/src/main/java/controllers/CommandLineInterface.java
+++ b/src/main/java/controllers/CommandLineInterface.java
@@ -18,6 +18,37 @@ import workers.ScheduleImporter;
 public class CommandLineInterface {
 
     public CommandLineInterface() {}
+    private int generationMode;
+
+    /** Constructor.
+     *
+     * @param mode represents one by one generation for the Controller
+     * 0 -> creates all permutations
+     * 1 -> one by one generation
+     *
+     * if one by one generation is used in controller, displayUserSchedule will take input to return a schedule
+     */
+    public CommandLineInterface(int mode) {
+        generationMode = mode;
+    }
+
+    /** Gets generation mode.
+     *
+     * @return generationMode
+     */
+    public int getGenerationMode() {
+        return generationMode;
+    }
+
+    /** Sets generation mode.
+     *
+     * @param i must be either 0 or 1. If i is not 0 or 1 this method does nothing.
+     */
+    public void setGenerationMode(int i) {
+        if (i == 0 || i == 1) {
+            generationMode = i;
+        }
+    }
 
     /**
      * Prompts user for input, asking whether they would like to import a schedule or make a new
@@ -26,7 +57,7 @@ public class CommandLineInterface {
      * @return an integer representing whether the user wants to import or creates a new schedule 0
      *     -> import 1 -> new schedule other integer -> exit program
      */
-    public static int promptUser() {
+    public int promptUser() {
         Scanner scanner = new Scanner(System.in);
 
         System.out.println("=== We Do A Little Scheduling :) ===");
@@ -55,7 +86,7 @@ public class CommandLineInterface {
      *
      * @return a String list of course codes
      */
-    public static List<String> promptCourseCodeNames() {
+    public List<String> promptCourseCodeNames() {
         Scanner scanner = new Scanner(System.in);
         boolean input = false;
         int numCourses = 0;
@@ -93,7 +124,7 @@ public class CommandLineInterface {
      *
      * @return a user-saved schedule that courses will be added to
      */
-    public static Schedule promptImportSchedule() {
+    public Schedule promptImportSchedule() {
         Scanner scanner = new Scanner(System.in);
         Schedule importedSchedule = new Schedule();
         boolean success = false;
@@ -127,7 +158,7 @@ public class CommandLineInterface {
      * @param userCourses the courses the user will take
      * @return a list of filters for their schedules
      */
-    public static List<Filter> promptUserFilters(List<Course> userCourses) {
+    public List<Filter> promptUserFilters(List<Course> userCourses) {
         ArrayList<Filter> userFilters = new ArrayList<>();
 
         Scanner scanner = new Scanner(System.in);
@@ -138,7 +169,8 @@ public class CommandLineInterface {
                     + "3 - Enforce a time gap between courses\n"
                     + "4 - Enforce times when you have no courses\n"
                     + "Please enter your choices as valid integer inputs with spaces. (i.e. '1 2"
-                    + " 3' or '2' or '').A non-integer input will end selection.\n");
+                    + " 3' or '2' or '').\n"
+                    + "A non-integer input will end selection.\n");
 
         boolean[] filterCodes = new boolean[4];
 
@@ -174,11 +206,73 @@ public class CommandLineInterface {
     }
 
     /**
+     * Confirms whether user wants to generate all schedules or use one by one generation.
+     */
+    public void confirmOneByOneGeneration() {
+        Scanner scanner = new Scanner(System.in);
+        System.out.println(
+                "Would you like to generate schedules one by one?\n"
+                + "Your schedule will be populated with only one course at a time to allow for specific time slot"
+                + " selection.\n"
+                + "1/0 for Y/N. \n"
+                + "Non-integer inputs will quit selection."
+        );
+        while (scanner.hasNextInt()) {
+            int input = scanner.nextInt();
+            if (input == 1 || input == 0) {
+                this.generationMode = input;
+                return;
+            }
+        }
+    }
+
+    /** Asks user to select the next base schedule for permutation in Scheduler.
+     *
+     * @param userSchedules the schedules meeting previous user specifications with one more course being permuted
+     * @return if the user selects a schedule around
+     */
+    public Schedule promptUserBaseSchedule(List<Schedule> userSchedules) {
+        Scanner scanner = new Scanner(System.in);
+        System.out.println("Schedules populated the next course on your priority list have been generated.\n"
+                + "Please select the schedule around which you want other time slots to be populated."
+        );
+        Schedule nextSchedule = this.displayUserSchedules(userSchedules);
+
+        if (nextSchedule == null) {
+            System.out.println("You have not selected a schedule.\n" +
+                    " The scheduler will generate all available schedules meeting previous specifications."
+            );
+        }
+        System.out.println(
+                "Would you like to continue one-by-one generation?\n"
+                        + "Your schedule will be populated with only the next course along with your currently selected"
+                        + " base schedule.\n"
+                        + "1/0 for Y/N. \n"
+                        + "Non-integer inputs will quit selection."
+        );
+        while (scanner.hasNextInt()) {
+            int input = scanner.nextInt();
+            if (input == 1 || input == 0) {
+                this.generationMode = input;
+                return nextSchedule;
+            }
+        }
+        return nextSchedule;
+    }
+
+
+
+    /**
      * Outputs schedules meeting user criteria. User can navigate through schedules and save them.
      *
      * @param userSchedules schedules meeting filter criteria
+     *
+     * attribute 'generationMode' is used in this method with
+     * 0 -> returning a Schedule is not an option
+     * 1 -> returning a Schedule is an option
+     * Note: returning a schedule is required in 1 by 1 generation
      */
-    public static void displayUserSchedules(List<Schedule> userSchedules) {
+    public Schedule displayUserSchedules(List<Schedule> userSchedules) {
         Scanner scanner = new Scanner(System.in);
         int numOfSchedules = userSchedules.size() - 1;
         int scheduleNumber = 0;
@@ -186,7 +280,7 @@ public class CommandLineInterface {
 
         if (numOfSchedules == -1) {
             System.out.println("No schedules meeting these criteria could be created.");
-            return;
+            return null;
         }
 
         while (userActivity != 'Q') {
@@ -201,6 +295,9 @@ public class CommandLineInterface {
             System.out.println("Press '>' to go to the next schedule.");
             System.out.println("Press '<' to go to the previous schedule.");
             System.out.println("Press 'S' to save this schedule as an .ics file");
+            if (this.generationMode == 1) {
+                System.out.println("Press 'X' to build courses around this schedule");
+            }
 
             char userInput = scanner.next().charAt(0);
             switch (userInput) {
@@ -225,8 +322,14 @@ public class CommandLineInterface {
                     System.out.println("Saving this schedule in .ics format...");
                     ScheduleExporter.outputScheduleICS(currSchedule);
                     break;
+                case 'X':
+                    if (this.generationMode == 1) {
+                        return currSchedule;
+                    }
+                    break;
             }
         }
+        return null;
     }
 
     /**

--- a/src/main/java/controllers/CommandLineInterface.java
+++ b/src/main/java/controllers/CommandLineInterface.java
@@ -18,7 +18,7 @@ import workers.ScheduleImporter;
 public class CommandLineInterface {
 
     public CommandLineInterface() {}
-    private int generationMode;
+    private GenerationMode generationMode;
 
     /** Constructor.
      *
@@ -28,7 +28,7 @@ public class CommandLineInterface {
      *
      * if one by one generation is used in controller, displayUserSchedule will take input to return a schedule
      */
-    public CommandLineInterface(int mode) {
+    public CommandLineInterface(GenerationMode mode) {
         generationMode = mode;
     }
 
@@ -36,18 +36,16 @@ public class CommandLineInterface {
      *
      * @return generationMode
      */
-    public int getGenerationMode() {
+    public GenerationMode getGenerationMode() {
         return generationMode;
     }
 
     /** Sets generation mode.
      *
-     * @param i must be either 0 or 1. If i is not 0 or 1 this method does nothing.
+     * @param mode must be enum ONE_BY_ONE or ALL_PERMUTATIONS as described in enum class GenerationMode
      */
-    public void setGenerationMode(int i) {
-        if (i == 0 || i == 1) {
-            generationMode = i;
-        }
+    public void setGenerationMode(GenerationMode mode) {
+        generationMode = mode;
     }
 
     /**
@@ -219,8 +217,11 @@ public class CommandLineInterface {
         );
         while (scanner.hasNextInt()) {
             int input = scanner.nextInt();
-            if (input == 1 || input == 0) {
-                this.generationMode = input;
+            if (input == 1) {
+                this.generationMode = GenerationMode.ONE_BY_ONE;
+                return;
+            } if (input == 0) {
+                this.generationMode = GenerationMode.ALL_PERMUTATIONS;
                 return;
             }
         }
@@ -249,8 +250,11 @@ public class CommandLineInterface {
         );
         while (scanner.hasNextInt()) {
             int input = scanner.nextInt();
-            if (input == 1 || input == 0) {
-                this.generationMode = input;
+            if (input == 1) {
+                this.generationMode = GenerationMode.ONE_BY_ONE;
+                return nextSchedule;
+            } if (input == 0) {
+                this.generationMode = GenerationMode.ALL_PERMUTATIONS;
                 return nextSchedule;
             }
         }
@@ -292,7 +296,7 @@ public class CommandLineInterface {
             System.out.println("Press '>' to go to the next schedule.");
             System.out.println("Press '<' to go to the previous schedule.");
             System.out.println("Press 'S' to save this schedule as an .ics file");
-            if (this.generationMode == 1) {
+            if (this.generationMode == GenerationMode.ONE_BY_ONE) {
                 System.out.println("Press 'X' to build courses around this schedule");
             }
 
@@ -320,7 +324,7 @@ public class CommandLineInterface {
                     ScheduleExporter.outputScheduleICS(currSchedule);
                     break;
                 case 'X':
-                    if (this.generationMode == 1) {
+                    if (this.generationMode == GenerationMode.ONE_BY_ONE) {
                         return currSchedule;
                     }
                     break;
@@ -533,6 +537,21 @@ public class CommandLineInterface {
             } catch (ArrayIndexOutOfBoundsException exception) {
                 System.out.println("Invalid input. PLEASE use HH:MM format in 24 HOUR TIME:");
             }
+        }
+    }
+
+    public enum GenerationMode {
+        ALL_PERMUTATIONS(0),
+        ONE_BY_ONE(1);
+
+        private final int generationMode;
+
+        GenerationMode(int i) {
+            this.generationMode = i;
+        }
+
+        public int getDay() {
+            return generationMode;
         }
     }
 }

--- a/src/main/java/controllers/CommandLineInterface.java
+++ b/src/main/java/controllers/CommandLineInterface.java
@@ -204,7 +204,7 @@ public class CommandLineInterface {
     /**
      * Confirms whether user wants to generate all schedules or use one by one generation.
      */
-    public void confirmOneByOneGeneration() {
+    public void selectGenerationMode() {
         Scanner scanner = new Scanner(System.in);
         System.out.println(
                 "Would you like to generate schedules one by one?\n"

--- a/src/main/java/controllers/CommandLineInterface.java
+++ b/src/main/java/controllers/CommandLineInterface.java
@@ -105,8 +105,8 @@ public class CommandLineInterface {
         int a = 0;
         while (a < numCourses) {
             System.out.println(
-                    "Please give the course code and session of one of your courses. An example of"
-                            + " expected format is MAT237Y. Accepted Sessions are (F,S,Y)");
+                    "Please give the course code and session of one of your courses." +
+                            "\nAn example of expected format is MAT237Y. Accepted Sessions are (F,S,Y)");
             String courseInput = scanner.nextLine();
             Matcher matcher = validInput.matcher(courseInput);
             if (matcher.find()) {
@@ -233,20 +233,17 @@ public class CommandLineInterface {
      */
     public Schedule promptUserBaseSchedule(List<Schedule> userSchedules) {
         Scanner scanner = new Scanner(System.in);
-        System.out.println("Schedules populated the next course on your priority list have been generated.\n"
-                + "Please select the schedule around which you want other time slots to be populated."
+        System.out.println("Please select the schedule around which you want other time slots to be populated."
         );
         Schedule nextSchedule = this.displayUserSchedules(userSchedules);
 
         if (nextSchedule == null) {
             System.out.println("You have not selected a schedule.\n" +
-                    " The scheduler will generate all available schedules meeting previous specifications."
+                    "The scheduler will generate all available schedules meeting previous specifications."
             );
         }
         System.out.println(
                 "Would you like to continue one-by-one generation?\n"
-                        + "Your schedule will be populated with only the next course along with your currently selected"
-                        + " base schedule.\n"
                         + "1/0 for Y/N. \n"
                         + "Non-integer inputs will quit selection."
         );

--- a/src/main/java/controllers/Controller.java
+++ b/src/main/java/controllers/Controller.java
@@ -49,8 +49,6 @@ public class Controller {
 
         /**
          * ask user if they want one by one schedule generation.
-         *  1 - yes
-         *  0 - no
          */
         CLI.confirmOneByOneGeneration();
 

--- a/src/main/java/controllers/Controller.java
+++ b/src/main/java/controllers/Controller.java
@@ -4,6 +4,7 @@ import entities.*;
 import filters.Filter;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import workers.*;
 
@@ -20,34 +21,70 @@ public class Controller {
          */
         // create our scheduler object
         Scheduler scheduler = new Scheduler();
+        CommandLineInterface CLI = new CommandLineInterface(1);
 
         /**
-         * Check if user wants to import or create new schedules. 1 -> new schedules 0 -> import -1
-         * -> do nothing
+         * Check if user wants to import or create new schedules.
+         * 1 -> new schedules
+         * 0 -> import
+         * -1 -> do nothing
          */
-        int userStrategy = CommandLineInterface.promptUser();
+        int userStrategy = CLI.promptUser();
         if (userStrategy == -1) {
             return;
         } else if (userStrategy == 0) {
-            Schedule baseSchedule = CommandLineInterface.promptImportSchedule();
+            Schedule baseSchedule = CLI.promptImportSchedule();
             scheduler.setBaseSchedule(baseSchedule);
         }
         // ask user for course codes
-        List<String> courses = CommandLineInterface.promptCourseCodeNames();
-
+        List<String> courses = CLI.promptCourseCodeNames();
         // course objects are instantiated based on the passed course codes
         List<Course> instantiatedCourses = Controller.courseInstantiator(courses);
 
         // get user specified filters, add them as filters to our scheduler object
-        List<Filter> filters = CommandLineInterface.promptUserFilters(instantiatedCourses);
+        List<Filter> filters = CLI.promptUserFilters(instantiatedCourses);
         scheduler.addFilters(filters);
+
+        /**
+         * ask user if they want one by one schedule generation.
+         *  1 - yes
+         *  0 - no
+         */
+        CLI.confirmOneByOneGeneration();
+
+        /**
+         * while the user wants one by one generation, keep repeating
+         */
+        //final user schedules
+        List<Schedule> schedules = new ArrayList<>();
+
+        while (CLI.getGenerationMode() == 1 || instantiatedCourses.size() > 1) {
+            Course nextCourse = instantiatedCourses.get(0);
+            List<Schedule> nextCourseSchedules = scheduler.permutationScheduler(nextCourse);
+            Schedule nextBase = CLI.promptUserBaseSchedule(nextCourseSchedules);
+            if (nextBase == null) {
+                CLI.setGenerationMode(0);
+            } else {
+                instantiatedCourses.remove(0);
+                scheduler.setBaseSchedule(nextBase);
+            }
+            if (instantiatedCourses.size() == 0) {
+                CLI.setGenerationMode(0);
+            }
+        }
+
+        CLI.setGenerationMode(0);
 
         // call the scheduler to give us all schedules given these courses, filters, and base
         // schedule
-        List<Schedule> schedules = scheduler.permutationScheduler(instantiatedCourses);
+        if (instantiatedCourses.size() != 0) {
+            schedules = scheduler.permutationScheduler(instantiatedCourses);
+        } else {
+            schedules = new ArrayList<>(List.of(scheduler.getBaseSchedule()));
+        }
 
         // user interactive output method
-        CommandLineInterface.displayUserSchedules(schedules);
+        CLI.displayUserSchedules(schedules);
     }
 
     /**

--- a/src/main/java/controllers/Controller.java
+++ b/src/main/java/controllers/Controller.java
@@ -50,7 +50,7 @@ public class Controller {
         /**
          * ask user if they want one by one schedule generation.
          */
-        CLI.confirmOneByOneGeneration();
+        CLI.selectGenerationMode();
 
         /**
          * while the user wants one by one generation, keep repeating

--- a/src/main/java/controllers/Controller.java
+++ b/src/main/java/controllers/Controller.java
@@ -21,7 +21,9 @@ public class Controller {
          */
         // create our scheduler object
         Scheduler scheduler = new Scheduler();
-        CommandLineInterface CLI = new CommandLineInterface(1);
+        CommandLineInterface.GenerationMode oneByOne = CommandLineInterface.GenerationMode.ONE_BY_ONE;
+        CommandLineInterface.GenerationMode allPermutations = CommandLineInterface.GenerationMode.ALL_PERMUTATIONS;
+        CommandLineInterface CLI = new CommandLineInterface(oneByOne);
 
         /**
          * Check if user wants to import or create new schedules.
@@ -58,19 +60,19 @@ public class Controller {
         //final user schedules
         List<Schedule> schedules = new ArrayList<>();
 
-        while (CLI.getGenerationMode() == 1 && instantiatedCourses.size() > 0) {
+        while (CLI.getGenerationMode() == oneByOne && instantiatedCourses.size() > 0) {
             Course nextCourse = instantiatedCourses.get(0);
             List<Schedule> nextCourseSchedules = scheduler.permutationScheduler(nextCourse);
             Schedule nextBase = CLI.promptUserBaseSchedule(nextCourseSchedules);
             if (nextBase == null) {
-                CLI.setGenerationMode(0);
+                CLI.setGenerationMode(allPermutations);
             } else {
                 instantiatedCourses.remove(0);
                 scheduler.setBaseSchedule(nextBase);
             }
         }
 
-        CLI.setGenerationMode(0);
+        CLI.setGenerationMode(allPermutations);
 
         // call the scheduler to give us all schedules given these courses, filters, and base
         // schedule

--- a/src/main/java/controllers/Controller.java
+++ b/src/main/java/controllers/Controller.java
@@ -58,7 +58,7 @@ public class Controller {
         //final user schedules
         List<Schedule> schedules = new ArrayList<>();
 
-        while (CLI.getGenerationMode() == 1 || instantiatedCourses.size() > 1) {
+        while (CLI.getGenerationMode() == 1 && instantiatedCourses.size() > 0) {
             Course nextCourse = instantiatedCourses.get(0);
             List<Schedule> nextCourseSchedules = scheduler.permutationScheduler(nextCourse);
             Schedule nextBase = CLI.promptUserBaseSchedule(nextCourseSchedules);
@@ -67,9 +67,6 @@ public class Controller {
             } else {
                 instantiatedCourses.remove(0);
                 scheduler.setBaseSchedule(nextBase);
-            }
-            if (instantiatedCourses.size() == 0) {
-                CLI.setGenerationMode(0);
             }
         }
 

--- a/src/main/java/entities/Schedule.java
+++ b/src/main/java/entities/Schedule.java
@@ -96,6 +96,10 @@ public class Schedule implements Cloneable {
         return false;
     }
 
+    public boolean isEmpty() {
+        return lectures.isEmpty();
+    }
+
     @Override
     public Schedule clone() {
         return new Schedule(

--- a/src/main/java/workers/Scheduler.java
+++ b/src/main/java/workers/Scheduler.java
@@ -34,6 +34,10 @@ public class Scheduler {
         this.schedule = schedule;
     }
 
+    public Schedule getBaseSchedule() {
+        return schedule;
+    }
+
     public void addFilters(List<Filter> filters) {
         this.filters.addAll(filters);
     }
@@ -70,6 +74,19 @@ public class Scheduler {
             // return savedSchedules;
             return newSchedules;
         }
+    }
+
+    /**
+     * An override of permutationScheduler but with one course. Used as a shortcut so no unnecessary ArrayList creation
+     * is needed in other classes
+     *
+     * @param course is the course whose lectures and sessions will be used in generation
+     * @return a list of all possible Schedules passing the given filters
+     */
+    public List<Schedule> permutationScheduler(Course course) {
+        ArrayList<Course> courseList = new ArrayList<>();
+        courseList.add(course);
+        return permutationScheduler(courseList);
     }
 
     /**


### PR DESCRIPTION
Implemented one-by-one user schedule generation. User populates courses one by one which allows for selection of specific course sections. Subsequent courses are 'permuted' on top of selected time slots.

CommandLineInterface calls are now nonstatic, and the class now has an instance attribute in order to manage input options when displaying schedules. Please see comments for more

I tested this with MAT257/CSC207. So far there seem to be no problems. It is difficult to write tests for these types of things, so please let me know if you run into errors. 

The terminal input is also very crude. I will work on this when we refactor the entirety of CommandLine Interface. For now, it works, but is confusing.

Maybe I will add PR template to this later